### PR TITLE
Added weight tying

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,7 +203,7 @@ cell = rnn_cell_modern.JZS3Cell(num_units)
 
 https://arxiv.org/abs/1608.05859
 
-Tying the input word embeding to the softmax matrix. 
+Tying the input word embeding to the softmax matrix. Because of the similarities between the input embedding and the softmax matrix (AKA the output embedding), setting them to be equal improves preplexity while reducing the number of parameters in the model. 
 ```python
 softmax_w = tf.transpose(embedding)
 ```

--- a/README.md
+++ b/README.md
@@ -198,3 +198,12 @@ cell = rnn_cell_modern.JZS2Cell(num_units)
 #Or
 cell = rnn_cell_modern.JZS3Cell(num_units)
 ```
+
+### Weight Tying
+
+https://arxiv.org/abs/1608.05859
+
+Tying the input word embeding to the softmax matrix. 
+```python
+softmax_w = tf.transpose(embedding)
+```

--- a/ptb_word_lm.py
+++ b/ptb_word_lm.py
@@ -137,7 +137,7 @@ class PTBModel(object):
         outputs.append(cell_output)
 
     output = tf.reshape(tf.concat(1, outputs), [-1, size])
-    softmax_w = tf.get_variable("softmax_w", [size, vocab_size])
+    softmax_w = tf.transpose(embedding) # weight tying
     softmax_b = tf.get_variable("softmax_b", [vocab_size])
     logits = tf.matmul(output, softmax_w) + softmax_b
     loss = tf.nn.seq2seq.sequence_loss_by_example(


### PR DESCRIPTION
As we recently showed in [1], tying the input word embedding to the softmax matrix decreases perplexity on a wide range of language models.

I implemented weight tying, and also ran tests comparing weight tied models to "regular" models, to make sure that it also improves the performance of the various models in this repo. The results are:

> 
>REGULAR:
>-- rnn_cell = rnn_cell_modern.MGUCell(size, use_multiplicative_integration = True, use_recurrent_dropout = False)
>Epoch: 13 Train Perplexity: 50.346
>Epoch: 13 Valid Perplexity: 131.284
>Test Perplexity: 125.133
>
>-- rnn_cell = rnn_cell_mulint_layernorm_modern.HighwayRNNCell_MulInt_LayerNorm(size)
>Epoch: 13 Train Perplexity: 54.869
>Epoch: 13 Valid Perplexity: 123.373
>Test Perplexity: 117.859
>
>-- rnn_cell = rnn_cell_mulint_modern.GRUCell_MulInt(size)
>Epoch: 13 Train Perplexity: 49.530
>Epoch: 13 Valid Perplexity: 126.091
>Test Perplexity: 120.613

>WEIGHT TIED:
>-- rnn_cell = rnn_cell_modern.MGUCell(size, use_multiplicative_integration = True, use_recurrent_dropout = False)
>Epoch: 13 Train Perplexity: 61.479
>Epoch: 13 Valid Perplexity: 128.844
>Test Perplexity: 122.353

>-- rnn_cell = rnn_cell_mulint_layernorm_modern.HighwayRNNCell_MulInt_LayerNorm(size)
>Epoch: 13 Train Perplexity: 64.139
>Epoch: 13 Valid Perplexity: 120.395
>Test Perplexity: 114.491

>-- rnn_cell = rnn_cell_mulint_modern.GRUCell_MulInt(size)
>Epoch: 13 Train Perplexity: 60.983
>Epoch: 13 Valid Perplexity: 125.205
>Test Perplexity: 119.398

Clearly weight tying consistently reduces test set perplexity while increasing the train perplexity which indicates less overfitting. 


[1] https://arxiv.org/abs/1608.05859

